### PR TITLE
Allow specifying filters/validators by name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "*@dev",
-        "phpunit/PHPUnit": "3.7.*"
+        "phpunit/PHPUnit": "3.7.*",
+        "zendframework/zend-filter": "~2.0",
+        "zendframework/zend-validator": "~2.0"
     },
     "suggest": {
         "zendframework/zend-filter": "~2.0; Useful for filtering/normalizing argument values",


### PR DESCRIPTION
- Allow passing filters and validators by name (instead of requiring
  instances).
- Allow passing callables for filters and validators; cast them to
  `Zend\Filter\Callback` and `Zend\Validator\Callback`, respectively.

Inspired by @slaff via zendframework/zf2#6380
