### PR TITLE
Supplied useful filters

### DIFF
--- a/src/Filter/Explode.php
+++ b/src/Filter/Explode.php
@@ -1,0 +1,31 @@
+<?php
+namespace ZF\Console\Filter;
+
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+use Zend\Filter\FilterInterface;
+
+class Explode implements FilterInterface
+{
+    private $delimiter;
+
+    public function __construct($delimiter=',')
+    {
+        $this->delimiter = $delimiter;
+    }
+
+    /* (non-PHPdoc)
+     * @see \Zend\Filter\FilterInterface::filter()
+     */
+    public function filter($value)
+    {
+        if(!is_string($value)) {
+            return $value;
+        }
+
+        return explode($this->delimiter, $value);
+    }
+}

--- a/src/Filter/Json.php
+++ b/src/Filter/Json.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Console\Filter;
+
+use Zend\Filter\FilterInterface;
+
+class Json implements FilterInterface
+{
+
+    /* (non-PHPdoc)
+     * @see \Zend\Filter\FilterInterface::filter()
+     */
+    public function filter($value)
+    {
+        if(!is_string($value)) {
+            return $value;
+        }
+
+        @$data = json_decode($value, true);
+        if($data === false) {
+            return $value;
+        }
+
+        return $data;
+    }
+
+}

--- a/src/Filter/QueryString.php
+++ b/src/Filter/QueryString.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Console\Filter;
+
+use Zend\Filter\FilterInterface;
+use Zend\Stdlib\ArrayUtils;
+
+class QueryString implements FilterInterface
+{
+
+    /* (non-PHPdoc)
+     * @see \Zend\Filter\FilterInterface::filter()
+     */
+    public function filter($value)
+    {
+        if(!is_string($value)) {
+            return $value;
+        }
+
+        // check if the values is provided like a query string
+        $pairs = explode('&', $value);
+        foreach ($pairs as $pair) {
+            list($k, $v) = explode('=', $pair);
+
+            if(preg_match("/^(.*?)((\[(.*?)\])+)$/m",$k, $m)) {
+                $parts = explode('][',rtrim(ltrim($m[2],'['),']'));
+                $json = '{"'.implode('":{"', $parts).'": '.json_encode($v).str_pad('', count($parts),'}');
+                if(!isset($data[$m[1]])) {
+                    $data[$m[1]] = json_decode($json, true);
+                } else {
+                    $data[$m[1]] = ArrayUtils::merge($data[$m[1]], json_decode($json, true));
+                }
+            } else {
+                $data[$k] = $v;
+            }
+        }
+
+        return $data;
+    }
+}

--- a/test/FilterTest.php
+++ b/test/FilterTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Console;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use ZF\Console\Filter;
+
+class FilterTest extends TestCase
+{
+    public function testExplode()
+    {
+        $string = "foo,bar,baz";
+        $expected = array('foo','bar','baz');
+        $filter = new Filter\Explode();
+        $this->assertEquals($expected, $filter->filter($string));
+    }
+
+    public function testExplodePipeDelimiter()
+    {
+        $string = "foo|bar|baz";
+        $expected = array('foo','bar','baz');
+        $filter = new Filter\Explode('|');
+        $this->assertEquals($expected, $filter->filter($string));
+    }
+
+    public function testJson()
+    {
+        $string = '{"session.save_handler": "cluster", "something": "else"}';
+        $expected = array('session.save_handler'=> 'cluster', 'something'=> 'else');
+        $filter = new Filter\Json();
+        $this->assertEquals($expected, $filter->filter($string));
+    }
+
+    public function testQueryString()
+    {
+        $string = 'session.save_handler=cluster&something=else';
+        $expected = array('session.save_handler'=> 'cluster', 'something'=> 'else');
+        $filter = new Filter\QueryString();
+        $this->assertEquals($expected, $filter->filter($string));
+    }
+}


### PR DESCRIPTION
Suggested implementation for issue #6:

QueryString: to allow arguments such as --directives=session.save_handler=cluster&something=else, which would be parsed to the array ["session.save_handler" => "cluster", "something" => "else"]. PHP's parse_str() could be used for an initial implementation; however, it munges keys to valid PHP variable names, and thus a custom implementation should likely be used.

JSON: to allow arguments such as --directives='{"session.save_handler": "cluster", "something": "else"}', which would parse to the same value as in the QueryString example above.

Explode: to allow delimited arguments to be parsed to an array: --modules=foo,bar,baz would be come ['foo', 'bar', 'baz']. The delimiter would be a comma by default, but could be specified during instantiation (or, if using the FilterPluginManager, when requesting the filter).
