### PR TITLE
Simplify mapping the command name to the route

### DIFF
--- a/src/RouteCollection.php
+++ b/src/RouteCollection.php
@@ -82,7 +82,11 @@ class RouteCollection implements Countable, IteratorAggregate, RouteMatcherInter
         if (! isset($spec['route'])) {
             $spec['route'] = $spec['name'];
         }
-        $routeString = $spec['route'];
+        $routeString = $this->prependRouteWithCommand(
+            $name,
+            $spec['route'],
+            array_key_exists('prepend_command_to_route', $spec) ? $spec['prepend_command_to_route'] : true
+        );
 
         $constraints        = (isset($spec['constraints']) && is_array($spec['constraints']))                   ? $spec['constraints']          : array();
         $defaults           = (isset($spec['defaults']) && is_array($spec['defaults']))                         ? $spec['defaults']             : array();
@@ -265,5 +269,30 @@ class RouteCollection implements Countable, IteratorAggregate, RouteMatcherInter
                 break;
         }
         return $type;
+    }
+
+    /**
+     * Prepend the route with the command
+     *
+     * If the route does not start with the command already, and the
+     * `prepend_command_to_route` flag has not been toggled off, then prepend
+     * the command to the route and return it.
+     *
+     * @param string $command
+     * @param string $route
+     * @param bool $prependFlag
+     * @return string
+     */
+    protected function prependRouteWithCommand($command, $route, $prependFlag)
+    {
+        if (true !== $prependFlag) {
+            return $route;
+        }
+
+        if (preg_match('/^(?:' . preg_quote($command) . ')(?:\s|$)/', $route)) {
+            return $route;
+        }
+
+        return sprintf('%s %s', $command, $route);
     }
 }

--- a/test/RouteCollectionTest.php
+++ b/test/RouteCollectionTest.php
@@ -183,4 +183,56 @@ class RouteCollectionTest extends TestCase
         $route = $this->collection->getRoute('foo');
         $this->assertEquals('foo', $route->getRoute());
     }
+
+    /**
+     * @group 5
+     */
+    public function testRouteNamePrependedToCommandByDefaultWhenNameDoesNotMatchInitialRouteSequence()
+    {
+        $spec = array(
+            'name' => 'foo',
+            'route' => '<bar>',
+        );
+        $this->collection->addRouteSpec($spec);
+        $this->assertEquals(1, count($this->collection));
+        $this->assertTrue($this->collection->hasRoute('foo'));
+
+        $route = $this->collection->getRoute('foo');
+        $this->assertEquals('foo <bar>', $route->getRoute());
+    }
+
+    /**
+     * @group 5
+     */
+    public function testRouteNameNotPrependedToCommandWhenNameMatchesInitialRouteSequence()
+    {
+        $spec = array(
+            'name' => 'foo',
+            'route' => 'foo <bar>',
+        );
+        $this->collection->addRouteSpec($spec);
+        $this->assertEquals(1, count($this->collection));
+        $this->assertTrue($this->collection->hasRoute('foo'));
+
+        $route = $this->collection->getRoute('foo');
+        $this->assertEquals('foo <bar>', $route->getRoute());
+    }
+
+    /**
+     * @group 5
+     */
+    public function testRouteNameNotPrependedToCommandWhenFlagSaysNotTo()
+    {
+        $spec = array(
+            'name' => 'foo',
+            'route' => '<bar>',
+            'prepend_command_to_route' => false,
+        );
+        $this->collection->addRouteSpec($spec);
+        $this->assertEquals(1, count($this->collection));
+        $this->assertTrue($this->collection->hasRoute('foo'));
+
+        $route = $this->collection->getRoute('foo');
+        $this->assertEquals('<bar>', $route->getRoute());
+    }
 }


### PR DESCRIPTION
The command name could be prepended to the route provided:

``` php
    array(
        'name' => 'fetch-all',
        'route' => '[--output=]',
    )
```

would evaluate to:

``` php
    'fetch-all [--output=]'
```

This could even be such that you could opt-out if you wanted:

``` php
    array(
        'name' => 'version',
        'route' => '[--version|-v]'
        'prepend_command_to_route' => false,
    ),
```

Finally, if the route already starts with the command name, no changes would be made:

``` php
    array(
        'name' => 'fetch-all',
        'route' => 'fetch-all [--output=]',
    ),
```

The last ensures BC, the middle allows opting-out of the 1:1 mapping when desired, and the first removes redundancy for the most common use case.

The intention is to codify https://github.com/zfcampus/zf-console/commit/f82408249267d37cb5629c9066066d0172d6957f#diff-c9248b3167fc44af085b81db2e292837R136
