### PR TITLE
Refactored Application.php to show banner and footer on each run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.idea

--- a/src/Application.php
+++ b/src/Application.php
@@ -154,10 +154,32 @@ class Application
             $args = array_slice($argv, 1);
         }
 
+        $this->showMessage($this->banner);
+
+        $result = $this->processRun($args);
+
+        $this->showMessage($this->footer);
+
+        return $result;
+    }
+
+    /**
+     * Process run
+     * If the argument list is empty, displays a usage message.
+     *
+     * If arguments are provided, but no routes match, displays a usage message
+     * and returns a status of 1.
+     *
+     * Otherwise, attempts to dispatch the matched command, returning the
+     * execution status.
+     *
+     * @param array $args
+     * @return int
+     */
+    protected function processRun(array $args)
+    {
         if (empty($args)) {
-            $this->showMessage($this->banner);
             $this->showUsageMessage();
-            $this->showMessage($this->footer);
             return 0;
         }
 
@@ -203,7 +225,7 @@ class Application
      * If the message is a callable, calls it with the composed console
      * instance as an argument.
      *
-     * @param string|callable $message
+     * @param string|callable $messageOrCallable
      */
     public function showMessage($messageOrCallable)
     {
@@ -298,7 +320,10 @@ class Application
 
     /**
      * Sets the debug flag of the application
+     *
      * @param boolean $flag
+     *
+     * @return $this
      */
     public function setDebug($flag)
     {
@@ -396,9 +421,7 @@ class Application
         $banner = $this->banner; // PHP < 5.4 compat
         $footer = $this->footer; // PHP < 5.4 compat
         $dispatcher->map('help', function ($route, $console) use ($help, $self, $banner, $footer) {
-            $self->showMessage($banner);
             $help($route, $console);
-            $self->showMessage($footer);
             return 0;
         });
     }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -72,7 +72,7 @@ class ApplicationTest extends TestCase
 
     public function testRunThatDoesNotMatchRoutesDisplaysUnmatchedRouteMessage()
     {
-        $this->console->expects($this->at(0))
+        $this->console->expects($this->at(4))
             ->method('write')
             ->with($this->stringContains('Unrecognized command:'));
 
@@ -102,8 +102,8 @@ class ApplicationTest extends TestCase
 
         $writeLines = $writeLineSpy->getInvocations();
         $this->assertGreaterThanOrEqual(3, count($writeLines));
-        $this->assertContains('Usage:', $writeLines[0]->toString());
-        $this->assertContains('build ', $writeLines[1]->toString());
+        $this->assertContains('Usage:', $writeLines[2]->toString());
+        $this->assertContains('build ', $writeLines[3]->toString());
 
         $writes = $writeSpy->getInvocations();
         $this->assertGreaterThanOrEqual(2, count($writes));


### PR DESCRIPTION
If you change the default banner and footer it will not shown on the default help command. This is due to the fact, that the `$this->setupHelpCommand()` is called within the `__construct()` right after the change of the banner to use the `showVersion()` method.

This PR is making sure that the banner and footer are shown on each application run. The tests were broken by this change so I fixed them as well.

Looking forward for any feedback.  
