### PR TITLE
Allow pulling commands from container

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,31 @@ The `Route` instance contains several methods of interest:
 - `getName()` will return the name of the route (which may be useful if you use the same callable
   for multiple routes).
 
+Pulling commands from container
+-------------------------------
+
+You can keep your commands in service container, compatible with `container-interop`. In order 
+to do so, inject your container into `Dispatcher` object upon creation:
+
+```php
+$serviceManager = new ServiceManager(/* ... */);
+
+// use `zend-servicemanager` as container
+$dispatcher = new Dispatcher($serviceManager);
+
+$routes = [
+    [
+        'name' => 'hello',        
+        'handler' => HelloCommand::class,
+    ]
+];
+
+$application = new Application('App', 1.0, $routes, null, $dispatcher);
+```
+
+In this example, when `hello` route is matched, `Dispatcher` will try to pull `HelloCommand` from 
+container and then execute it.
+
 Exception Handling
 ------------------
 

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,13 @@
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3.1",
         "zendframework/zend-filter": "~2.3",
-        "zendframework/zend-validator": "~2.3"
+        "zendframework/zend-validator": "~2.3",
+        "container-interop/container-interop": "^1.1"
     },
     "suggest": {
         "zendframework/zend-filter": "~2.3; Useful for filtering/normalizing argument values",
-        "zendframework/zend-validator": "~2.3; Useful for providing more thorough argument validation logic"
+        "zendframework/zend-validator": "~2.3; Useful for providing more thorough argument validation logic",
+        "container-interop/container-interop": "^1.1; For ability to pull dispatched commands from container"
     },
     "autoload": {
         "psr-4": {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -70,7 +70,6 @@ class Dispatcher
         $callable = $this->commandMap[$name];
 
         if (! is_callable($callable) && is_string($callable)) {
-
             if ($this->container && $this->container->has($callable)) {
                 $callable = $this->container->get($callable);
             } else {

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Console;
 
+use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use RuntimeException;
 use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
@@ -14,6 +15,19 @@ use Zend\Console\ColorInterface as Color;
 class Dispatcher
 {
     protected $commandMap = [];
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     */
+    public function __construct(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     public function map($command, $callable)
     {
@@ -56,12 +70,17 @@ class Dispatcher
         $callable = $this->commandMap[$name];
 
         if (! is_callable($callable) && is_string($callable)) {
-            $callable = new $callable();
+
+            if ($this->container && $this->container->has($callable)) {
+                $callable = $this->container->get($callable);
+            } else {
+                $callable = new $callable();
+            }
+
             if (! is_callable($callable)) {
-                throw new RuntimeException(sprintf(
-                    'Invalid command class specified for "%s"; class must be invokable',
-                    $name
-                ));
+                throw new RuntimeException(
+                    sprintf('Invalid command class specified for "%s"; class must be invokable', $name)
+                );
             }
             $this->commandMap[$name] = $callable;
         }

--- a/src/Route.php
+++ b/src/Route.php
@@ -156,7 +156,7 @@ class Route extends DefaultRouteMatcher
      */
     public function isMatched()
     {
-        return is_array($matches);
+        return is_array($this->matches);
     }
 
     /**

--- a/test/DispatcherTest.php
+++ b/test/DispatcherTest.php
@@ -6,13 +6,20 @@
 
 namespace ZFTest\Console;
 
+use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Console\Adapter\AdapterInterface;
 use ZF\Console\Dispatcher;
 use ZF\Console\Route;
+use ZFTest\Console\TestAsset\FooCommand;
 
 class DispatcherTest extends TestCase
 {
+    /**
+     * @var Dispatcher
+     */
+    private $dispatcher;
+
     public function setUp()
     {
         $this->route = $this->getMockBuilder('ZF\Console\Route')
@@ -90,5 +97,21 @@ class DispatcherTest extends TestCase
             ->method('getName')
             ->will($this->returnValue('test'));
         $this->assertEquals(2, $this->dispatcher->dispatch($this->route, $this->console));
+    }
+
+    public function testDispatchCanPullCommandFromContainer()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(FooCommand::class)->willReturn(true);
+        $container->get(FooCommand::class)->willReturn(new FooCommand());
+
+        $route = $this->prophesize(Route::class);
+        $route->getName()->willReturn('foobar');
+
+        $console = $this->prophesize(AdapterInterface::class);
+
+        $dispatcher = new Dispatcher($container->reveal());
+        $dispatcher->map('foobar', FooCommand::class);
+        $dispatcher->dispatch($route->reveal(), $console->reveal());
     }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -75,6 +75,19 @@ class RouteTest extends TestCase
         $this->assertSame($matches, $route->getMatches());
     }
 
+    public function testIsMatchedReturnsFalseByDefault()
+    {
+        $route = new Route('foo', 'foo bar');
+        $this->assertFalse($route->isMatched());
+    }
+
+    public function testIsMatchedReturnsTrueOnSuccesfulMatch()
+    {
+        $route = new Route('foo', 'foo bar');
+        $route->match(['foo', 'bar']);
+        $this->assertTrue($route->isMatched());
+    }
+
     public function testMatchedParamReturnsTrueForParameterMatched()
     {
         $route = new Route('foo', 'foo <bar>');

--- a/test/TestAsset/FooCommand.php
+++ b/test/TestAsset/FooCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZFTest\Console\TestAsset;
+
+class FooCommand
+{
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
This PR updates `Dispatcher` class, so that it can optionally pull commands from `container-interop`-compatible container. 

Usage:

```php
$serviceManager = new ServiceManager(/* ... */);
$dispatcher = new Dispatcher($serviceManager);
$application = new Application('App', 1.0, $routes, null, $dispatcher);
```

After configuration, you can specify valid identifier as route `handler`, and `Dispatcher` will try to retrieve it when route is matched. This can help to lazily load complex command objects requiring configuration via factory.

Solves #15.