### PR TITLE
Add ability to disable the default banner

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -439,21 +439,24 @@ class Application
     /**
      * Disables the banner for user commands. Still shows it before usage messages.
      *
+     * @param bool $flag
+     *
      * @return self
      */
-    public function disableBannerForUserCommands()
+    public function setBannerDisabledForUserCommands($flag = true)
     {
-        $this->bannerDisabledForUserCommands = true;
+        $this->bannerDisabledForUserCommands = (bool) $flag;
         return $this;
     }
 
     /**
-     * @return self
+     * Whether or not to disable the banner in user commands. False by default.
+     *
+     * @return bool
      */
-    public function enableBannerForUserCommands()
+    public function isBannerDisabledForUserCommands()
     {
-        $this->bannerDisabledForUserCommands = false;
-        return $this;
+        return $this->bannerDisabledForUserCommands;
     }
 
     /**

--- a/src/Application.php
+++ b/src/Application.php
@@ -294,14 +294,12 @@ class Application
      * If the default help implementation is used, also displayed with help
      * messages.
      *
-     * @param string|callable $bannerOrCallable
+     * @param null|string|callable $bannerOrCallable
      * @return self
      */
     public function setBanner($bannerOrCallable)
     {
-        if (! is_string($bannerOrCallable) && ! is_callable($bannerOrCallable)) {
-            throw new InvalidArgumentException('Banner must be a string message or callable');
-        }
+        $this->validateMessage($bannerOrCallable);
         $this->banner = $bannerOrCallable;
         return $this;
     }
@@ -314,14 +312,12 @@ class Application
      * If the default help implementation is used, also displayed with help
      * messages.
      *
-     * @param string|callable $footerOrCallable
+     * @param null|string|callable $footerOrCallable
      * @return self
      */
     public function setFooter($footerOrCallable)
     {
-        if (! is_string($footerOrCallable) && ! is_callable($footerOrCallable)) {
-            throw new InvalidArgumentException('Footer must be a string message or callable');
-        }
+        $this->validateMessage($footerOrCallable);
         $this->footer = $footerOrCallable;
         return $this;
     }
@@ -632,5 +628,15 @@ class Application
         }
 
         $this->dispatcher->map($command, $route['handler']);
+    }
+
+    /**
+     * @param mixed $stringOrCallable
+     */
+    protected function validateMessage($stringOrCallable)
+    {
+        if ($stringOrCallable !== null && ! is_string($stringOrCallable) && ! is_callable($stringOrCallable)) {
+            throw new InvalidArgumentException('Messages must be string or callable');
+        }
     }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -208,7 +208,7 @@ class Application
             return 1;
         }
 
-        if(! $this->bannerDisabledForUserCommands) {
+        if (! $this->bannerDisabledForUserCommands) {
             $this->showMessage($this->banner);
         }
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -307,7 +307,9 @@ class ApplicationTest extends TestCase
                 'route' => 'test',
                 'description' => 'Test handler capabilities',
                 'short_description' => 'Test handler capabilities',
-                'handler' => function ($route, AdapterInterface $console) { $console->write('test output'); },
+                'handler' => function ($route, AdapterInterface $console) {
+                    $console->write('test output');
+                },
             ],
         ]);
         $application->disableBannerForUserCommands();

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -312,7 +312,7 @@ class ApplicationTest extends TestCase
                 },
             ],
         ]);
-        $application->disableBannerForUserCommands();
+        $application->setBannerDisabledForUserCommands();
 
         ob_start();
 

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -6,6 +6,7 @@
 
 namespace ZFTest\Console;
 
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
 use Zend\Console\Adapter\AdapterInterface;
@@ -15,6 +16,11 @@ use ZF\Console\Route;
 
 class ApplicationTest extends TestCase
 {
+    /**
+     * @var AdapterInterface|MockObject
+     */
+    private $console;
+
     public function setUp()
     {
         $this->version = uniqid();
@@ -276,5 +282,20 @@ class ApplicationTest extends TestCase
     {
         $this->setExpectedException('DomainException', 'registered');
         $this->application->removeRoute('does-not-exist');
+    }
+
+    public function testCanDisableBanner()
+    {
+        $application = new Application('test-name', 'foo-version', []);
+        $application->setBanner(null);
+
+        ob_start();
+
+        $application->run();
+
+        $buffer = ob_get_clean();
+
+        $this->assertNotContains('test-name', $buffer);
+        $this->assertNotContains('foo-version', $buffer);
     }
 }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -284,7 +284,7 @@ class ApplicationTest extends TestCase
         $this->application->removeRoute('does-not-exist');
     }
 
-    public function testCanDisableBanner()
+    public function testCanSetBannerToNull()
     {
         $application = new Application('test-name', 'foo-version', []);
         $application->setBanner(null);
@@ -297,5 +297,27 @@ class ApplicationTest extends TestCase
 
         $this->assertNotContains('test-name', $buffer);
         $this->assertNotContains('foo-version', $buffer);
+    }
+
+    public function testCanDisableBannerOnlyForCommands()
+    {
+        $application = new Application('test-app', 'test-version', [
+            [
+                'name'  => 'test',
+                'route' => 'test',
+                'description' => 'Test handler capabilities',
+                'short_description' => 'Test handler capabilities',
+                'handler' => function ($route, AdapterInterface $console) { $console->write('test output'); },
+            ],
+        ]);
+        $application->disableBannerForUserCommands();
+
+        ob_start();
+
+        $application->run([ 'test' ]);
+
+        $buffer = ob_get_clean();
+
+        $this->assertSame('test output', $buffer);
     }
 }


### PR DESCRIPTION
This PR makes two changes in the `Application` api.

- `setBanner` and `setFooter` now accept null values. Prior to this, the only way to disable the banner was to pass an noop anonymous function.
- `Application::$bannerDisabledForUserCommands` property and accessors are introduced, to enable disabling the banner just for the user commands. The main use case is to use the application output in conjunction with other CLI tools, e.g. via pipes and output redirection.