### PR TITLE
Proposal: DispatcherInterface

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -35,7 +35,7 @@ class Application
     protected $debug = false;
 
     /**
-     * @var Dispatcher
+     * @var DispatcherInterface
      */
     protected $dispatcher;
 
@@ -79,14 +79,14 @@ class Application
      * @param string $version Application version
      * @param array|Traversable $routes Routes/route specifications to use for the application
      * @param Console $console Console adapter to use within the application
-     * @param Dispatcher $dispatcher Configured dispatcher mapping routes to callables
+     * @param DispatcherInterface $dispatcher Configured dispatcher mapping routes to callables
      */
     public function __construct(
         $name,
         $version,
         $routes,
         Console $console = null,
-        Dispatcher $dispatcher = null
+        DispatcherInterface $dispatcher = null
     ) {
         if (! is_array($routes) && ! $routes instanceof Traversable) {
             throw new InvalidArgumentException('Routes must be provided as an array or Traversable object');
@@ -126,7 +126,7 @@ class Application
     }
 
     /**
-     * @return Dispatcher
+     * @return DispatcherInterface
      */
     public function getDispatcher()
     {
@@ -436,9 +436,9 @@ class Application
      * Creates the route, and maps the command.
      *
      * @param RouteCollection $routeCollection
-     * @param Dispatcher $dispatcher
+     * @param DispatcherInterface $dispatcher
      */
-    protected function setupHelpCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupHelpCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         $help = new HelpCommand($this);
         $routeCollection->addRouteSpec([
@@ -474,9 +474,9 @@ class Application
      * Creates the route, and maps the command.
      *
      * @param RouteCollection $routeCollection
-     * @param Dispatcher $dispatcher
+     * @param DispatcherInterface $dispatcher
      */
-    protected function setupVersionCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupVersionCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         $routeCollection->addRouteSpec([
             'name' => 'version',
@@ -502,9 +502,9 @@ class Application
      * Creates the route, and maps the command.
      *
      * @param RouteCollection $routeCollection
-     * @param Dispatcher $dispatcher
+     * @param DispatcherInterface $dispatcher
      */
-    protected function setupAutocompleteCommand(RouteCollection $routeCollection, Dispatcher $dispatcher)
+    protected function setupAutocompleteCommand(RouteCollection $routeCollection, DispatcherInterface $dispatcher)
     {
         $routeCollection->addRouteSpec([
                 'name' => 'autocomplete',

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -11,7 +11,7 @@ use RuntimeException;
 use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
 use Zend\Console\ColorInterface as Color;
 
-class Dispatcher
+class Dispatcher implements DispatcherInterface
 {
     protected $commandMap = [];
 

--- a/src/DispatcherInterface.php
+++ b/src/DispatcherInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Console;
+
+use Zend\Console\Adapter\AdapterInterface as ConsoleAdapter;
+
+interface DispatcherInterface
+{
+    public function map($command, $callable);
+
+    /**
+     * Does the dispatcher have a handler for the given command?
+     *
+     * @param string $command
+     * @return bool
+     */
+    public function has($command);
+
+    public function dispatch(Route $route, ConsoleAdapter $console);
+}


### PR DESCRIPTION
This pull Request introduces a "DispatcherInerface" for the easy exchange of the dispatcher with own implementations.

In my project I have a plugin manager that provides me the commands. To integrate this into the dispatcher, it was only possible by inheritance, which has led to some difficulties.
The interface would have been easier.

```php
<?php

$commands = [....];
$commandManager = new CommandManager($commands);
$commandDispatcher = new CommandDispatcher($commandManager);
$application = new Application(
        'FooApp',
        '99.0.0',
        [....],
        null,
        $commandDispatcher);
$application->run();

// ...
```

I also thought about to mark the dispatcher as `final`, but that would mean a BC break, which is why this will be done at a later date.

Thoughts?