### PR TITLE
remove version_compare(PHP_VERSION, '5.5', 'lt')

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -556,10 +556,6 @@ class Application
      */
     protected function setProcessTitle()
     {
-        if (version_compare(PHP_VERSION, '5.5', 'lt')) {
-            return;
-        }
-
         // Mac OS X does not support cli_set_process_title() due to security issues
         // Bug fix for issue https://github.com/zfcampus/zf-console/issues/21
         if (PHP_OS == 'Darwin') {


### PR DESCRIPTION
as minimal requirement is php 5.6

- [x] Is this related to quality assurance?
