### PR TITLE
Adding a HandlerInterface definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,25 @@ arguments:
 - The `ZF\Console\Route` instance that matched
 - The `Zend\Console` adapter currently in use
 
+You may create the callable by implementing `ZF\Console\HandlerInterface`, which defines the following method:
+
+    namespace ZF\Console;
+
+    use Zend\Console\Adapter\AdapterInterface;
+
+    interface HandlerInterface
+    {
+
+       /**
+        * Invokable for Zf/Console Route handler
+        *
+        * @param Route $route
+        * @param AdapterInterface $console
+        */
+
+       public function __invoke(Route $route, AdapterInterface $console);
+    }
+
 In most cases, you will use the `Route` instance to gather arguments passed to the application, and
 the `Console` instance to provide any feedback or to prompt for any additional information.
 

--- a/src/HandlerInterface.php
+++ b/src/HandlerInterface.php
@@ -1,0 +1,23 @@
+<?php
+namespace ZF\Console;
+
+use Zend\Console\Adapter\AdapterInterface;
+
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+interface HandlerInterface
+{
+    
+    /**
+     * Invokable for Zf/Console Route handler
+     * 
+     * @param Route $route
+     * @param AdapterInterface $console
+     */
+    
+    public function __invoke( Route $route, AdapterInterface $console);
+}
+

--- a/src/HandlerInterface.php
+++ b/src/HandlerInterface.php
@@ -20,4 +20,3 @@ interface HandlerInterface
 
     public function __invoke(Route $route, AdapterInterface $console);
 }
-

--- a/src/HandlerInterface.php
+++ b/src/HandlerInterface.php
@@ -10,14 +10,14 @@ use Zend\Console\Adapter\AdapterInterface;
 
 interface HandlerInterface
 {
-    
+
     /**
      * Invokable for Zf/Console Route handler
-     * 
+     *
      * @param Route $route
      * @param AdapterInterface $console
      */
-    
-    public function __invoke( Route $route, AdapterInterface $console);
+
+    public function __invoke(Route $route, AdapterInterface $console);
 }
 


### PR DESCRIPTION
This is simply to add an interface definition to faciliate the creation of route handlers.

I have been using this for a while now and works fine in editor like phpStorm and Zend Studio.  The editors will add the `__invoke( Route $route, AdapterInterface $console)` automatically.

It also helps enforce the proper function definition.

Usage:

    use Zend\Console\Adapter\AdapterInterface;
    use ZF\Console\HandlerInterface;
    use ZF\Console\Route;

    class MyHandler implements HandlerInterface
    {

    /**
     * Invokable for Zf/Console Route handler
     *
     * @param Route $route
     * @param AdapterInterface $console
     */
    public function __invoke(Route $route, AdapterInterface $console)
    {
        ...
    }
   }